### PR TITLE
Add database schema model and LocalDB configuration

### DIFF
--- a/src/database/config/LocalDbConfig.java
+++ b/src/database/config/LocalDbConfig.java
@@ -1,0 +1,70 @@
+package database.config;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Configuration helper for connecting to the Microsoft SQL Server LocalDB
+ * instance that ships with the SQL Server Express edition.
+ *
+ * <p>The configuration exposes a ready-to-use JDBC URL and a helper method that
+ * creates a {@link Connection} using integrated security. The default instance
+ * name provided by Microsoft is {@code MSSQLLocalDB}, therefore the connection
+ * string is built around the {@code (localdb)\\MSSQLLocalDB} server name.</p>
+ */
+public class LocalDbConfig {
+
+        private static final String DEFAULT_INSTANCE = "(localdb)\\\\MSSQLLocalDB";
+        private static final String JDBC_DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
+
+        private final String databaseName;
+        private final Properties connectionProperties;
+
+        public LocalDbConfig(String databaseName) {
+                this(databaseName, buildDefaultProperties());
+        }
+
+        public LocalDbConfig(String databaseName, Properties connectionProperties) {
+                this.databaseName = Objects.requireNonNull(databaseName, "Database name is required");
+                this.connectionProperties = new Properties();
+                this.connectionProperties.putAll(connectionProperties);
+        }
+
+        public String getDatabaseName() {
+                return databaseName;
+        }
+
+        public Properties getConnectionProperties() {
+                Properties copy = new Properties();
+                copy.putAll(connectionProperties);
+                return copy;
+        }
+
+        public String getConnectionUrl() {
+                return "jdbc:sqlserver://" + DEFAULT_INSTANCE + ";databaseName=" + databaseName + ";";
+        }
+
+        public Connection openConnection() throws SQLException {
+                loadDriverIfRequired();
+                return DriverManager.getConnection(getConnectionUrl(), connectionProperties);
+        }
+
+        private void loadDriverIfRequired() {
+                try {
+                        Class.forName(JDBC_DRIVER_CLASS);
+                } catch (ClassNotFoundException ex) {
+                        throw new IllegalStateException("The Microsoft SQL Server JDBC driver is not available on the classpath", ex);
+                }
+        }
+
+        private static Properties buildDefaultProperties() {
+                Properties props = new Properties();
+                props.setProperty("encrypt", "true");
+                props.setProperty("trustServerCertificate", "true");
+                props.setProperty("integratedSecurity", "true");
+                return props;
+        }
+}

--- a/src/database/model/CategoryEntity.java
+++ b/src/database/model/CategoryEntity.java
@@ -1,0 +1,71 @@
+package database.model;
+
+import java.util.Objects;
+
+public class CategoryEntity {
+
+        private long categoryId;
+        private String categoryName;
+        private String description;
+
+        public CategoryEntity() {
+        }
+
+        public CategoryEntity(long categoryId, String categoryName, String description) {
+                this.categoryId = categoryId;
+                this.categoryName = categoryName;
+                this.description = description;
+        }
+
+        public long getCategoryId() {
+                return categoryId;
+        }
+
+        public void setCategoryId(long categoryId) {
+                this.categoryId = categoryId;
+        }
+
+        public String getCategoryName() {
+                return categoryName;
+        }
+
+        public void setCategoryName(String categoryName) {
+                this.categoryName = categoryName;
+        }
+
+        public String getDescription() {
+                return description;
+        }
+
+        public void setDescription(String description) {
+                this.description = description;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+                if (this == o) {
+                        return true;
+                }
+                if (!(o instanceof CategoryEntity)) {
+                        return false;
+                }
+                CategoryEntity that = (CategoryEntity) o;
+                return categoryId == that.categoryId
+                        && Objects.equals(categoryName, that.categoryName)
+                        && Objects.equals(description, that.description);
+        }
+
+        @Override
+        public int hashCode() {
+                return Objects.hash(categoryId, categoryName, description);
+        }
+
+        @Override
+        public String toString() {
+                return "CategoryEntity{" +
+                        "categoryId=" + categoryId +
+                        ", categoryName='" + categoryName + '\'' +
+                        ", description='" + description + '\'' +
+                        '}';
+        }
+}

--- a/src/database/model/ColumnDefinition.java
+++ b/src/database/model/ColumnDefinition.java
@@ -1,0 +1,138 @@
+package database.model;
+
+import java.util.Objects;
+
+public class ColumnDefinition {
+
+        private final String name;
+        private final SqlDataType dataType;
+        private final Integer length;
+        private final Integer scale;
+        private final boolean nullable;
+        private final boolean primaryKey;
+        private final boolean identity;
+        private final String references;
+
+        private ColumnDefinition(Builder builder) {
+                this.name = builder.name;
+                this.dataType = builder.dataType;
+                this.length = builder.length;
+                this.scale = builder.scale;
+                this.nullable = builder.nullable;
+                this.primaryKey = builder.primaryKey;
+                this.identity = builder.identity;
+                this.references = builder.references;
+        }
+
+        public String getName() {
+                return name;
+        }
+
+        public SqlDataType getDataType() {
+                return dataType;
+        }
+
+        public Integer getLength() {
+                return length;
+        }
+
+        public Integer getScale() {
+                return scale;
+        }
+
+        public boolean isNullable() {
+                return nullable;
+        }
+
+        public boolean isPrimaryKey() {
+                return primaryKey;
+        }
+
+        public boolean isIdentity() {
+                return identity;
+        }
+
+        public String getReferences() {
+                return references;
+        }
+
+        public String toSql() {
+                StringBuilder builder = new StringBuilder();
+                builder.append('[').append(name).append(']').append(' ');
+                builder.append(dataType.getKeyword());
+                if (length != null && scale == null) {
+                        builder.append('(').append(length).append(')');
+                } else if (length != null) {
+                        builder.append('(').append(length).append(',').append(scale).append(')');
+                }
+                if (identity) {
+                        builder.append(" IDENTITY(1,1)");
+                }
+                if (!nullable || primaryKey) {
+                        builder.append(" NOT NULL");
+                }
+                if (primaryKey) {
+                        builder.append(" PRIMARY KEY");
+                }
+                if (references != null) {
+                        builder.append(" REFERENCES ").append(references);
+                }
+                return builder.toString();
+        }
+
+        public static Builder builder(String name, SqlDataType dataType) {
+                return new Builder(name, dataType);
+        }
+
+        public static final class Builder {
+                private final String name;
+                private final SqlDataType dataType;
+                private Integer length;
+                private Integer scale;
+                private boolean nullable = true;
+                private boolean primaryKey;
+                private boolean identity;
+                private String references;
+
+                private Builder(String name, SqlDataType dataType) {
+                        this.name = Objects.requireNonNull(name, "Column name");
+                        this.dataType = Objects.requireNonNull(dataType, "SQL data type");
+                }
+
+                public Builder withLength(int value) {
+                        this.length = value;
+                        return this;
+                }
+
+                public Builder withLengthAndScale(int length, int scale) {
+                        this.length = length;
+                        this.scale = scale;
+                        return this;
+                }
+
+                public Builder notNull() {
+                        this.nullable = false;
+                        return this;
+                }
+
+                public Builder asPrimaryKey() {
+                        this.primaryKey = true;
+                        this.nullable = false;
+                        return this;
+                }
+
+                public Builder withIdentity() {
+                        this.identity = true;
+                        return this;
+                }
+
+                public Builder references(String table, String column) {
+                        this.references = '[' + table + "].[" + column + ']';
+                        return this;
+                }
+
+                public ColumnDefinition build() {
+                        return new ColumnDefinition(this);
+                }
+        }
+}

--- a/src/database/model/DatabaseModel.java
+++ b/src/database/model/DatabaseModel.java
@@ -1,0 +1,96 @@
+package database.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class DatabaseModel {
+
+        private final List<TableDefinition> tables;
+
+        private DatabaseModel(List<TableDefinition> tables) {
+                this.tables = Collections.unmodifiableList(new ArrayList<>(tables));
+        }
+
+        public static DatabaseModel createDefaultModel() {
+                List<TableDefinition> tables = new ArrayList<>();
+                tables.add(createProductTable());
+                tables.add(createCategoryTable());
+                tables.add(createInventoryTable());
+                return new DatabaseModel(tables);
+        }
+
+        public List<TableDefinition> getTables() {
+                return tables;
+        }
+
+        public List<String> toCreateTableStatements() {
+                List<String> statements = new ArrayList<>();
+                for (TableDefinition table : tables) {
+                        statements.add(table.toCreateTableStatement());
+                }
+                return statements;
+        }
+
+        private static TableDefinition createProductTable() {
+                return TableDefinition.builder("Products")
+                        .withColumn(ColumnDefinition.builder("ProductId", SqlDataType.BIGINT)
+                                .withIdentity()
+                                .asPrimaryKey()
+                                .build())
+                        .withColumn(ColumnDefinition.builder("ProductName", SqlDataType.NVARCHAR)
+                                .withLength(200)
+                                .notNull()
+                                .build())
+                        .withColumn(ColumnDefinition.builder("Description", SqlDataType.NVARCHAR)
+                                .withLength(1000)
+                                .build())
+                        .withColumn(ColumnDefinition.builder("Price", SqlDataType.DECIMAL)
+                                .withLengthAndScale(10, 2)
+                                .notNull()
+                                .build())
+                        .withColumn(ColumnDefinition.builder("Active", SqlDataType.BIT)
+                                .notNull()
+                                .build())
+                        .withColumn(ColumnDefinition.builder("CategoryId", SqlDataType.BIGINT)
+                                .notNull()
+                                .build())
+                        .withConstraint("FOREIGN KEY ([CategoryId]) REFERENCES [ProductCategories]([CategoryId])")
+                        .build();
+        }
+
+        private static TableDefinition createCategoryTable() {
+                return TableDefinition.builder("ProductCategories")
+                        .withColumn(ColumnDefinition.builder("CategoryId", SqlDataType.BIGINT)
+                                .withIdentity()
+                                .asPrimaryKey()
+                                .build())
+                        .withColumn(ColumnDefinition.builder("CategoryName", SqlDataType.NVARCHAR)
+                                .withLength(150)
+                                .notNull()
+                                .build())
+                        .withColumn(ColumnDefinition.builder("Description", SqlDataType.NVARCHAR)
+                                .withLength(1000)
+                                .build())
+                        .build();
+        }
+
+        private static TableDefinition createInventoryTable() {
+                return TableDefinition.builder("ProductInventory")
+                        .withColumn(ColumnDefinition.builder("InventoryId", SqlDataType.BIGINT)
+                                .withIdentity()
+                                .asPrimaryKey()
+                                .build())
+                        .withColumn(ColumnDefinition.builder("ProductId", SqlDataType.BIGINT)
+                                .notNull()
+                                .build())
+                        .withColumn(ColumnDefinition.builder("Quantity", SqlDataType.INT)
+                                .notNull()
+                                .build())
+                        .withColumn(ColumnDefinition.builder("LastUpdated", SqlDataType.DATETIME2)
+                                .notNull()
+                                .build())
+                        .withConstraint("FOREIGN KEY ([ProductId]) REFERENCES [Products]([ProductId])")
+                        .build();
+        }
+}

--- a/src/database/model/InventoryRecord.java
+++ b/src/database/model/InventoryRecord.java
@@ -1,0 +1,82 @@
+package database.model;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class InventoryRecord {
+
+        private long inventoryId;
+        private long productId;
+        private int quantity;
+        private LocalDateTime lastUpdated;
+
+        public InventoryRecord() {
+        }
+
+        public InventoryRecord(long inventoryId, long productId, int quantity, LocalDateTime lastUpdated) {
+                this.inventoryId = inventoryId;
+                this.productId = productId;
+                this.quantity = quantity;
+                this.lastUpdated = lastUpdated;
+        }
+
+        public long getInventoryId() {
+                return inventoryId;
+        }
+
+        public void setInventoryId(long inventoryId) {
+                this.inventoryId = inventoryId;
+        }
+
+        public long getProductId() {
+                return productId;
+        }
+
+        public void setProductId(long productId) {
+                this.productId = productId;
+        }
+
+        public int getQuantity() {
+                return quantity;
+        }
+
+        public void setQuantity(int quantity) {
+                this.quantity = quantity;
+        }
+
+        public LocalDateTime getLastUpdated() {
+                return lastUpdated;
+        }
+
+        public void setLastUpdated(LocalDateTime lastUpdated) {
+                this.lastUpdated = lastUpdated;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+                if (this == o) {
+                        return true;
+                }
+                if (!(o instanceof InventoryRecord)) {
+                        return false;
+                }
+                InventoryRecord that = (InventoryRecord) o;
+                return inventoryId == that.inventoryId && productId == that.productId && quantity == that.quantity
+                        && Objects.equals(lastUpdated, that.lastUpdated);
+        }
+
+        @Override
+        public int hashCode() {
+                return Objects.hash(inventoryId, productId, quantity, lastUpdated);
+        }
+
+        @Override
+        public String toString() {
+                return "InventoryRecord{" +
+                        "inventoryId=" + inventoryId +
+                        ", productId=" + productId +
+                        ", quantity=" + quantity +
+                        ", lastUpdated=" + lastUpdated +
+                        '}';
+        }
+}

--- a/src/database/model/ProductEntity.java
+++ b/src/database/model/ProductEntity.java
@@ -1,0 +1,106 @@
+package database.model;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public class ProductEntity {
+
+        private long productId;
+        private String productName;
+        private String description;
+        private BigDecimal price;
+        private boolean active;
+        private long categoryId;
+
+        public ProductEntity() {
+        }
+
+        public ProductEntity(long productId, String productName, String description, BigDecimal price, boolean active, long categoryId) {
+                this.productId = productId;
+                this.productName = productName;
+                this.description = description;
+                this.price = price;
+                this.active = active;
+                this.categoryId = categoryId;
+        }
+
+        public long getProductId() {
+                return productId;
+        }
+
+        public void setProductId(long productId) {
+                this.productId = productId;
+        }
+
+        public String getProductName() {
+                return productName;
+        }
+
+        public void setProductName(String productName) {
+                this.productName = productName;
+        }
+
+        public String getDescription() {
+                return description;
+        }
+
+        public void setDescription(String description) {
+                this.description = description;
+        }
+
+        public BigDecimal getPrice() {
+                return price;
+        }
+
+        public void setPrice(BigDecimal price) {
+                this.price = price;
+        }
+
+        public boolean isActive() {
+                return active;
+        }
+
+        public void setActive(boolean active) {
+                this.active = active;
+        }
+
+        public long getCategoryId() {
+                return categoryId;
+        }
+
+        public void setCategoryId(long categoryId) {
+                this.categoryId = categoryId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+                if (this == o) {
+                        return true;
+                }
+                if (!(o instanceof ProductEntity)) {
+                        return false;
+                }
+                ProductEntity that = (ProductEntity) o;
+                return productId == that.productId && active == that.active && categoryId == that.categoryId
+                        && Objects.equals(productName, that.productName)
+                        && Objects.equals(description, that.description)
+                        && Objects.equals(price, that.price);
+        }
+
+        @Override
+        public int hashCode() {
+                return Objects.hash(productId, productName, description, price, active, categoryId);
+        }
+
+        @Override
+        public String toString() {
+                return "ProductEntity{" +
+                        "productId=" + productId +
+                        ", productName='" + productName + '\'' +
+                        ", description='" + description + '\'' +
+                        ", price=" + price +
+                        ", active=" + active +
+                        ", categoryId=" + categoryId +
+                        '}';
+        }
+}

--- a/src/database/model/SqlDataType.java
+++ b/src/database/model/SqlDataType.java
@@ -1,0 +1,22 @@
+package database.model;
+
+public enum SqlDataType {
+        BIGINT("BIGINT"),
+        INT("INT"),
+        BIT("BIT"),
+        MONEY("MONEY"),
+        DECIMAL("DECIMAL"),
+        NVARCHAR("NVARCHAR"),
+        DATETIME2("DATETIME2"),
+        UNIQUEIDENTIFIER("UNIQUEIDENTIFIER");
+
+        private final String keyword;
+
+        SqlDataType(String keyword) {
+                this.keyword = keyword;
+        }
+
+        public String getKeyword() {
+                return keyword;
+        }
+}

--- a/src/database/model/TableDefinition.java
+++ b/src/database/model/TableDefinition.java
@@ -1,0 +1,80 @@
+package database.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class TableDefinition {
+
+        private final String name;
+        private final List<ColumnDefinition> columns;
+        private final List<String> additionalConstraints;
+
+        private TableDefinition(Builder builder) {
+                this.name = builder.name;
+                this.columns = Collections.unmodifiableList(new ArrayList<>(builder.columns));
+                this.additionalConstraints = Collections.unmodifiableList(new ArrayList<>(builder.additionalConstraints));
+        }
+
+        public String getName() {
+                return name;
+        }
+
+        public List<ColumnDefinition> getColumns() {
+                return columns;
+        }
+
+        public List<String> getAdditionalConstraints() {
+                return additionalConstraints;
+        }
+
+        public String toCreateTableStatement() {
+                StringBuilder builder = new StringBuilder();
+                builder.append("CREATE TABLE [").append(name).append("] (");
+                for (int i = 0; i < columns.size(); i++) {
+                        builder.append(columns.get(i).toSql());
+                        if (i < columns.size() - 1 || !additionalConstraints.isEmpty()) {
+                                builder.append(',');
+                        }
+                        builder.append(System.lineSeparator()).append(' ');
+                }
+                for (int i = 0; i < additionalConstraints.size(); i++) {
+                        builder.append(additionalConstraints.get(i));
+                        if (i < additionalConstraints.size() - 1) {
+                                builder.append(',');
+                        }
+                        builder.append(System.lineSeparator()).append(' ');
+                }
+                builder.append(')');
+                return builder.toString();
+        }
+
+        public static Builder builder(String name) {
+                return new Builder(name);
+        }
+
+        public static final class Builder {
+                private final String name;
+                private final List<ColumnDefinition> columns = new ArrayList<>();
+                private final List<String> additionalConstraints = new ArrayList<>();
+
+                private Builder(String name) {
+                        this.name = Objects.requireNonNull(name, "Table name");
+                }
+
+                public Builder withColumn(ColumnDefinition column) {
+                        columns.add(Objects.requireNonNull(column, "column"));
+                        return this;
+                }
+
+                public Builder withConstraint(String constraintSql) {
+                        additionalConstraints.add(Objects.requireNonNull(constraintSql, "constraintSql"));
+                        return this;
+                }
+
+                public TableDefinition build() {
+                        return new TableDefinition(this);
+                }
+        }
+}

--- a/src/module-info.java
+++ b/src/module-info.java
@@ -1,9 +1,10 @@
 /**
- * 
+ *
  */
 /**
- * 
+ *
  */
 module learningjava {
-	requires java.desktop;
+        requires java.desktop;
+        requires java.sql;
 }


### PR DESCRIPTION
## Summary
- add a dedicated database model package with table, column and SQL type abstractions
- define product, category and inventory entities along with a default schema builder
- introduce LocalDB configuration helper and enable java.sql in the module descriptor

## Testing
- javac $(find src -name "*.java") *(fails: pre-existing compile errors in unrelated sources)*

------
https://chatgpt.com/codex/tasks/task_e_68dc06104e6483209f08507bea23e063